### PR TITLE
fix(api): 전체 목록 조회 오류 해결 및 api 호출 호직 api 패키지 안으로 통합 

### DIFF
--- a/src/api/path.js
+++ b/src/api/path.js
@@ -1,35 +1,35 @@
-import axios from 'axios';
+// import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+// const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-export const pathApi = {
-  /**
-   * Toggle like status for a path
-   * @param {number} pathId - The ID of the path to like/unlike
-   * @returns {Promise<Object>} Response data with updated like status
-   */
-  toggleLike: async (pathId) => {
-    try {
-      const response = await axios.post(
-        `${API_BASE_URL}paths/${pathId}/like-toggle`,
-        {},
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            // Add authorization header if needed
-            // 'Authorization': `Bearer ${localStorage.getItem('token')}`
-          },
-          withCredentials: true
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error('Error toggling like:', error);
-      throw error;
-    }
-  },
+// export const pathApi = {
+//   /**
+//    * Toggle like status for a path
+//    * @param {number} pathId - The ID of the path to like/unlike
+//    * @returns {Promise<Object>} Response data with updated like status
+//    */
+//   toggleLike: async (pathId) => {
+//     try {
+//       const response = await axios.post(
+//         `${API_BASE_URL}/paths/${pathId}/like-toggle`,
+//         {},
+//         {
+//           headers: {
+//             'Content-Type': 'application/json',
+//             // Add authorization header if needed
+//             // 'Authorization': `Bearer ${localStorage.getItem('token')}`
+//           },
+//           withCredentials: true
+//         }
+//       );
+//       return response.data;
+//     } catch (error) {
+//       console.error('Error toggling like:', error);
+//       throw error;
+//     }
+//   },
   
-  // You can add more path-related API calls here
-};
+//   // You can add more path-related API calls here
+// };
 
-export default pathApi;
+// export default pathApi;

--- a/src/api/paths.js
+++ b/src/api/paths.js
@@ -3,6 +3,34 @@ import apiClient from "./client";
 const PATH_API_URL = "/paths";
 
 export const pathsService = {
+  /**
+   * 산책 코스 목록 조회
+   * @param {Object} options
+   * @param {string} options.filter - ALL | EMOTIONAL | CITY_VIEW | NATURE | NIGHT_VIEW | SAFE
+   * @param {string} options.sort   - LATEST | RECOMMENDED | LIKES | DISTANCE
+   * @returns {Promise<Array>}
+   */
+  getPaths: async ({ filter = "ALL", sort = "LATEST" } = {}) => {
+    try {
+      const res = await apiClient.get(PATH_API_URL, {
+        params: { filter, sort },
+      });
+      return res.data.data; // APIResponse 구조에서 data 추출
+    } catch (error) {
+      console.error("산책 코스 목록 조회 오류:", error);
+      throw (
+        error.response?.data || {
+          message: "산책 코스를 불러오는 중 오류가 발생했습니다.",
+        }
+      );
+    }
+  },
+
+  /**
+   * 산책 코스 상세 조회
+   * @param {number} pathId
+   * @returns {Promise<Object>}
+   */
   getPathDetail: async (pathId) => {
     try {
       const res = await apiClient.get(`${PATH_API_URL}/${pathId}`);
@@ -16,4 +44,31 @@ export const pathsService = {
       );
     }
   },
+
+  /**
+   * 산책 코스 좋아요 토글
+   * @param {number} pathId
+   * @returns {Promise<Object>}
+   */
+  toggleLike: async (pathId) => {
+    try {
+      const res = await apiClient.post(
+        `${PATH_API_URL}/${pathId}/like-toggle`,
+        {},
+        {
+          headers: {
+            "Content-Type": "application/json",
+            // Authorization 필요하면 apiClient에서 자동 처리 가능
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data;
+    } catch (error) {
+      console.error(`산책 코스 좋아요 토글 오류 (ID: ${pathId}):`, error);
+      throw error.response?.data || { message: "좋아요 처리 중 오류 발생" };
+    }
+  },
 };
+
+export default pathsService;

--- a/src/pages/background/BackgroundPage.jsx
+++ b/src/pages/background/BackgroundPage.jsx
@@ -4,6 +4,8 @@ import styles from './BackgroundPage.module.css';
 import MenuBar from '../../components/common/MenuBar';
 import FloatingActionButtons from '../../components/common/FloatingActionButtons';
 import axios from 'axios';
+import { pathsService } from "../../api/paths";
+
 
 // 아이콘 및 이미지 임포트
 import areaLogo from '../../assets/images/logo/area_logo.svg';
@@ -29,40 +31,16 @@ const BackgroundPage = () => {
   // 카드의 좋아요 상태를 전환합니다
   const toggleLike = async (cardId) => {
     try {
-      const token = localStorage.getItem('accessToken');
-      const tokenType = localStorage.getItem('tokenType') || 'Bearer';
-      
-      const response = await axios.post(
-        `${import.meta.env.VITE_API_BASE_URL}paths/${cardId}/like-toggle`,
-        {},
-        {
-          headers: {
-            'Authorization': `${tokenType} ${token}`,
-            'Content-Type': 'application/json',
-          }/*,
-          withCredentials: true*/
-        }
-      );
+      const result = await pathsService.toggleLike(cardId);
+      const { is_liked, likes_count } = result.data;
 
-      if (response.data.isSuccess) {
-        const { is_liked, likes_count } = response.data.data;
-        
-        // Update the specific card's like status and count
-        setPathCards(prevCards => 
-          prevCards.map(card => 
-            card.id === cardId 
-              ? { ...card, is_liked, likes_count }
-              : card
-          )
-        );
-      }
+      setPathCards((prev) =>
+        prev.map((card) =>
+          card.id === cardId ? { ...card, is_liked, likes_count } : card
+        )
+      );
     } catch (error) {
-      console.error('Error toggling like:', error);
-      // Optionally show an error message to the user
-      if (error.response?.status === 401) {
-        // Handle unauthorized error (e.g., redirect to login)
-        console.log('토큰이 만료되었거나 유효하지 않습니다. 다시 로그인해주세요.');
-      }
+      console.error("좋아요 토글 오류:", error);
     }
   };
 
@@ -112,40 +90,19 @@ const BackgroundPage = () => {
   const fetchPaths = async () => {
     try {
       setLoading(true);
-      const token = localStorage.getItem('accessToken');
-      const tokenType = localStorage.getItem('tokenType') || 'Bearer';
-      
-      console.log('Sending request to:', `${import.meta.env.VITE_API_BASE_URL}paths`);
-      console.log('With token:', `${tokenType} ${token?.substring(0, 20)}...`);
-      
-      const response = await axios.get(
-        `${import.meta.env.VITE_API_BASE_URL}paths`,
-        {
-          params: {
-            filter: selectedCategory,
-            sort: sortBy,
-            // user_location: '37.5665,126.9780' // 현재 위치가 있다면 추가
-          },
-          headers: {
-            'Authorization': `${tokenType} ${token}`,
-            'Content-Type': 'application/json',
-          }
-          // withCredentials: true 제거
-        }
-      );
-
-      console.log('Response:', response);
-      
-      if (response.data.isSuccess) {
-        setPathCards(response.data.data);
-      }
+      const data = await pathsService.getPaths({
+        filter: selectedCategory,
+        sort: sortBy
+      });
+      setPathCards(data);
     } catch (err) {
-      console.error('Error fetching paths:', err);
-      setError('산책 코스를 불러오는 중 오류가 발생했습니다.');
+      console.error("산책 코스 조회 오류:", err);
+      setError("산책 코스를 불러오는 중 오류가 발생했습니다.");
     } finally {
       setLoading(false);
     }
   };
+
 
   // 카테고리나 정렬 기준이 변경될 때마다 데이터 다시 불러오기
   useEffect(() => {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #33 

## 📌 PR 제목 
전체 목록 조회 오류 해결 및 api 호출 호직 api 패키지 안으로 통합 

## 📝 작업 내용
<img width="315" height="661" alt="image" src="https://github.com/user-attachments/assets/c44a6a59-f890-479e-a159-d1f010c09bf7" />

- api 조회 로직 api 패키지 안으로 통합
- 백엔드 및 프론트에서 산책 코스 목록 조회 인가 로직 제거


## ✅ 체크리스트
- [x] 이 기능/수정이 정상적으로 동작하나요?
- [x] 배포 전 모든 테스트 통과했나요?
- [x] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [x] 브랜치 잘 지정했나요?
- [x] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
- 기존 api/path와 api/paths가 중복이라 api/paths으로 이동해 통합했습니다! 추가로 산책 코스 목록 조회 로직도 BackgroundPage.jsx에서 api/paths로 이동해두었어요
- 기존 api/path코드는 삭제하지 않고 우선 주석처리해두었습니다! 담당자께서 확인 후 삭제해주시며 좋을 것 같아요